### PR TITLE
Update Python wrappers

### DIFF
--- a/bmibabel/data/py.Component/Component_Impl.py
+++ b/bmibabel/data/py.Component/Component_Impl.py
@@ -431,7 +431,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_shape)
-    shape = self._model.get_grid_shape(grid)
+    shape[:] = self._model.get_grid_shape(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_shape)
 
@@ -450,7 +450,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_spacing)
-    spacing = self._model.get_grid_spacing(grid)
+    spacing[:] = self._model.get_grid_spacing(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_spacing)
 
@@ -469,7 +469,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_origin)
-    origin = self._model.get_grid_origin(grid)
+    origin[:] = self._model.get_grid_origin(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_origin)
 
@@ -488,7 +488,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_x)
-    x = self._model.get_grid_x(grid)
+    x[:] = self._model.get_grid_x(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_x)
 
@@ -507,7 +507,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_y)
-    y = self._model.get_grid_y(grid)
+    y[:] = self._model.get_grid_y(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_y)
 
@@ -526,7 +526,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_z)
-    z = self._model.get_grid_z(grid)
+    z[:] = self._model.get_grid_z(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_z)
 
@@ -545,7 +545,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_connectivity)
-    connectivity = self._model.get_grid_connectivity(grid)
+    connectivity[:] = self._model.get_grid_connectivity(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_connectivity)
 
@@ -564,7 +564,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_offset)
-    offset = self._model.get_grid_offset(grid)
+    offset[:] = self._model.get_grid_offset(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_offset)
 
@@ -583,7 +583,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_value)
-    dest = self._model.get_value(name)
+    dest[:] = self._model.get_value(name)
     return 0
 # DO-NOT-DELETE splicer.end(get_value)
 
@@ -622,7 +622,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_value_at_indices)
-    dest = self._model.get_value_at_indices(name, inds)
+    dest[:] = self._model.get_value_at_indices(name, inds)
     return 0
 # DO-NOT-DELETE splicer.end(get_value_at_indices)
 

--- a/bmibabel/data/py.Component/Component_Impl.py
+++ b/bmibabel/data/py.Component/Component_Impl.py
@@ -375,7 +375,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_type)
-    return (0, self._model.get_grid_type(name))
+    return (0, self._model.get_grid_type(grid))
 # DO-NOT-DELETE splicer.end(get_grid_type)
 
   def get_grid_rank(self, grid):
@@ -394,7 +394,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_rank)
-    return (0, self._model.get_grid_rank(name))
+    return (0, self._model.get_grid_rank(grid))
 # DO-NOT-DELETE splicer.end(get_grid_rank)
 
   def get_grid_size(self, grid):
@@ -413,7 +413,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_size)
-    return (0, self._model.get_grid_size(name))
+    return (0, self._model.get_grid_size(grid))
 # DO-NOT-DELETE splicer.end(get_grid_size)
 
   def get_grid_shape(self, grid, shape):
@@ -431,7 +431,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_shape)
-    self._model.get_grid_shape(name, shape)
+    self._model.get_grid_shape(grid, shape)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_shape)
 
@@ -450,7 +450,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_spacing)
-    self._model.get_grid_spacing(name, spacing)
+    self._model.get_grid_spacing(grid, spacing)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_spacing)
 
@@ -469,7 +469,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_origin)
-    self._model.get_grid_origin(name, origin)
+    self._model.get_grid_origin(grid, origin)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_origin)
 
@@ -488,7 +488,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_x)
-    self._model.get_grid_x(name, x)
+    self._model.get_grid_x(grid, x)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_x)
 
@@ -507,7 +507,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_y)
-    self._model.get_grid_y(name, y)
+    self._model.get_grid_y(grid, y)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_y)
 
@@ -526,7 +526,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_z)
-    self._model.get_grid_z(name, z)
+    self._model.get_grid_z(grid, z)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_z)
 
@@ -545,7 +545,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_connectivity)
-    self._model.get_grid_connectivity(name, connectivity)
+    self._model.get_grid_connectivity(grid, connectivity)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_connectivity)
 
@@ -564,7 +564,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_offset)
-    self._model.get_grid_offset(name, offset)
+    self._model.get_grid_offset(grid, offset)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_offset)
 

--- a/bmibabel/data/py.Component/Component_Impl.py
+++ b/bmibabel/data/py.Component/Component_Impl.py
@@ -431,7 +431,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_shape)
-    self._model.get_grid_shape(grid, shape)
+    shape = self._model.get_grid_shape(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_shape)
 
@@ -450,7 +450,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_spacing)
-    self._model.get_grid_spacing(grid, spacing)
+    spacing = self._model.get_grid_spacing(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_spacing)
 
@@ -469,7 +469,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_origin)
-    self._model.get_grid_origin(grid, origin)
+    origin = self._model.get_grid_origin(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_origin)
 
@@ -488,7 +488,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_x)
-    self._model.get_grid_x(grid, x)
+    x = self._model.get_grid_x(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_x)
 
@@ -507,7 +507,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_y)
-    self._model.get_grid_y(grid, y)
+    y = self._model.get_grid_y(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_y)
 
@@ -526,7 +526,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_z)
-    self._model.get_grid_z(grid, z)
+    z = self._model.get_grid_z(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_z)
 
@@ -545,7 +545,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_connectivity)
-    self._model.get_grid_connectivity(grid, connectivity)
+    connectivity = self._model.get_grid_connectivity(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_connectivity)
 
@@ -564,7 +564,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_grid_offset)
-    self._model.get_grid_offset(grid, offset)
+    offset = self._model.get_grid_offset(grid)
     return 0
 # DO-NOT-DELETE splicer.end(get_grid_offset)
 
@@ -583,7 +583,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_value)
-    self._model.get_value(name, dest)
+    dest = self._model.get_value(name)
     return 0
 # DO-NOT-DELETE splicer.end(get_value)
 
@@ -622,7 +622,7 @@ class Component:
     #
 
 # DO-NOT-DELETE splicer.begin(get_value_at_indices)
-    self._model.get_value_at_indices(name, dest, inds)
+    dest = self._model.get_value_at_indices(name, inds)
     return 0
 # DO-NOT-DELETE splicer.end(get_value_at_indices)
 


### PR DESCRIPTION
There are two changes in this pull request:
1. The local variable `name` was used in the `get_grid_*` routines, likely a holdover from the old way of calling them. I replaced `name` with the parameter `grid`.
2. Several of the getters (e.g., `get_grid_shape`) require output passed back through a numpy array. I updated the contents of the numpy array with the output from the associated BMI function.
