### PR TITLE
Include initialize_args in the list of valid keys

### DIFF
--- a/bmibabel/api.py
+++ b/bmibabel/api.py
@@ -17,7 +17,8 @@ _API_FILES = [os.path.join('.bmi', 'api.yaml'),
 
 _REQUIRED_KEYS = set(['language', ])
 _OPTIONAL_KEYS = set(['name', 'type', 'register', 'class', 'package',
-                      'libs', 'cflags', 'includes', 'build', 'path'])
+                      'libs', 'cflags', 'includes', 'build', 'path',
+                      'initialize_args'])
 _VALID_KEYS = _REQUIRED_KEYS | _OPTIONAL_KEYS
 
 


### PR DESCRIPTION
The `initialize_args` attribute can be used to specify the model configuration file (see, e.g., https://github.com/csdms/topoflow-bridge/blob/master/.bmi/meteorology/api.yaml). I'd like to include it in the list of optional keys for the **api.yaml** file.
