### PR TITLE
Tidy imports

### DIFF
--- a/bmibabel/build.py
+++ b/bmibabel/build.py
@@ -6,6 +6,7 @@ import os
 import sys
 import types
 import subprocess
+import warnings
 
 import yaml
 

--- a/bmibabel/cmd/bmi_babel_fetch.py
+++ b/bmibabel/cmd/bmi_babel_fetch.py
@@ -6,7 +6,6 @@ import os
 import sys
 import re
 import argparse
-import warnings
 import shutil
 
 import yaml

--- a/bmibabel/cmd/bmi_files.py
+++ b/bmibabel/cmd/bmi_files.py
@@ -6,7 +6,6 @@ import os
 import sys
 import re
 import argparse
-import warnings
 import shutil
 
 import yaml

--- a/bmibabel/cmd/bmi_find.py
+++ b/bmibabel/cmd/bmi_find.py
@@ -6,7 +6,6 @@ import os
 import sys
 import re
 import argparse
-import warnings
 import shutil
 
 import yaml

--- a/bmibabel/cmd/bmi_install.py
+++ b/bmibabel/cmd/bmi_install.py
@@ -6,7 +6,6 @@ import os
 import sys
 import re
 import argparse
-import warnings
 import shutil
 
 import yaml

--- a/bmibabel/cmd/bmi_parameters.py
+++ b/bmibabel/cmd/bmi_parameters.py
@@ -6,7 +6,6 @@ import os
 import sys
 import re
 import argparse
-import warnings
 import shutil
 
 import yaml

--- a/bmibabel/cmd/bmi_stage.py
+++ b/bmibabel/cmd/bmi_stage.py
@@ -6,7 +6,6 @@ import os
 import sys
 import re
 import argparse
-import warnings
 import shutil
 
 import yaml


### PR DESCRIPTION
This PR contains two changes:

1. Added import for `warnings` package to **build.py**.
1. Removed unused imports of `warnings` package from a few of the scripts in the `cmd` subpackage.