### PR TITLE
Load subcommands via bmi.plugins entry point.

### DIFF
--- a/bmibabel/cmd/bmi.py
+++ b/bmibabel/cmd/bmi.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+import sys
+
 from . import bmi_babelize as babelize
 from . import bmi_find as find
 from . import bmi_parameters as parameters
@@ -8,14 +10,38 @@ from . import bmi_files as files
 from . import bmi_install as install
 
 
+def load_subparsers(subparsers):
+    import pkg_resources
+
+    class Plugins(object):
+        pass
+
+
+    plugins = Plugins()
+
+
+    for entry_point in pkg_resources.iter_entry_points(group='bmi.plugins'):
+        try:
+            plugin = entry_point.load()
+        except Exception as err:
+            pass
+        else:
+            plugin(subparsers)
+
+
 def main():
     import argparse
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        fromfile_prefix_chars='@',
+    )
 
-    subparsers = parser.add_subparsers(title='subcommands',
-                                       description='valid commands',
-                                       help='additional help')
+    subparsers = parser.add_subparsers(
+        title='subcommands',
+        description='valid commands',
+        help='additional help',
+    )
+    subparsers.required = True
 
     babelize.create_parser(addto=subparsers)
     find.create_parser(addto=subparsers)
@@ -23,6 +49,8 @@ def main():
     stage.create_parser(addto=subparsers)
     files.create_parser(addto=subparsers)
     install.create_parser(addto=subparsers)
+
+    load_subparsers(subparsers)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This pull request adds a plugin framework to the *bmi* command as a way of loading additional subcommands. Plugins must register themselves under `bmi.plugins` and point to a function whose only input argument is an `ArgumentParser` object. The new command will then be available as a subcommand to *bmi*.